### PR TITLE
Inclusão do commitizen para padronização de contribuições

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,18 @@
     "generate:production": "dotenv -e .env.production -- turbo run generate --no-daemon",
     "generate:development": "dotenv -e .env.development -- turbo run generate --no-daemon",
     "lint": "turbo run lint",
-    "format": "prettier --write \"**/*.{ts,tsx,md}\""
+    "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "commit": "cz"
   },
   "devDependencies": {
     "dotenv-cli": "^7.2.1",
-    "turbo": "^1.10.12"
+    "turbo": "^1.10.12",
+    "commitizen": "4.3.0"
+  },
+  "config": {
+    "commitizen": {
+      "path": "cz-conventional-changelog"
+    }
   },
   "name": "my-turborepo",
   "packageManager": "pnpm@8.6.9"


### PR DESCRIPTION
## Resumo
Foi sugerido a padronização de mensagens de commits utilizando o [commitizen](https://github.com/commitizen/cz-cli) na issue #23

## Mudanças Realizadas
- Incluído o commitizen no projeto como uma dependência de desenvolvimento
- Incluído configuração do comitizen

## Tipo de Mudança
- [ ] feat: uma nova funcionalidade

## Capturas de tela
![image](https://github.com/menthorlabs/menthor/assets/6784777/2e1574bb-cce0-475e-8e23-a175169be094)

