### PR TITLE
Correção no link da imagem de contribuidores

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,10 +29,12 @@
       Feito com ❤︎ pelos
       <a href="https://github.com/menthorlabs/menthor/graphs/contributors">
         contribuidores
-        <p>
-        <img src="https://contrib.rocks/image?repo=menthorlabs/menthor&anon=0&columns=20&max=100&align=center" />
-        </p>
       </a>
+        <p>
+          <a href="https://github.com/menthorlabs/menthor/graphs/contributors">
+            <img src="https://contrib.rocks/image?repo=menthorlabs/menthor&anon=0&columns=20&max=100&align=center" />
+          </a>
+        </p>
     </sub>
   </p>
   <br />


### PR DESCRIPTION
## Resumo

Como o código havia sido montado, com o link sendo aberto dentro de um parágrafo e fechado no outro, a imagem estava recebendo o link na pré-visualização. Porém, ao subir para produção, o link se quebrou, ficando apenas no _"contribuidores"_, e a imagem ficando com seu link de abertura - o que não era a intenção, mas sim, abrir a página de contribuidores.

Dessa forma, fechei o link anterior como estava e inseri uma nova tag de link apenas para a imagem, dentro de seu parágrafo.

## Mudanças Realizadas

_Antes:_
```
    <sub>
      Feito com ❤︎ pelos

------- <a href="https://github.com/menthorlabs/menthor/graphs/contributors">

        contribuidores
        <p>
        <img src="https://contrib.rocks/image?repo=menthorlabs/menthor&anon=0&columns=20&max=100&align=center" />
        </p>

------- </a>

    </sub>
```

_Depois:_
```
<sub>
      Feito com ❤︎ pelos

------- <a href="https://github.com/menthorlabs/menthor/graphs/contributors">
        contribuidores
------- </a>

        <p>

------- <a href="https://github.com/menthorlabs/menthor/graphs/contributors">
            <img src="https://contrib.rocks/image?repo=menthorlabs/menthor&anon=0&columns=20&max=100&align=center" />
------- </a>

        </p>
    </sub>
```

## Tipo de Mudança

- [X] docs: somente modificações de documentação

## Capturas de tela

![image](https://github.com/menthorlabs/menthor/assets/110077540/551a32aa-7d09-429d-bad0-a908a23d316c)
