### PR TITLE
fix: required  form signup

### DIFF
--- a/apps/app/pages/sign-up.vue
+++ b/apps/app/pages/sign-up.vue
@@ -85,11 +85,12 @@ async function clerkOAuth(strategy) {
         @click="clerkOAuth('oauth_google')"
       />
     </div>
-    <MForm>
+    <MForm @submit="createAccount()">
       <MTextField
         class="mb-4"
         label="Email"
         type="email"
+        required
         v-model="email"
         :rules="['email']"
       />
@@ -98,6 +99,7 @@ async function clerkOAuth(strategy) {
         label="Senha"
         type="password"
         v-model="password"
+        required
         :rules="['password']"
       />
       <MButton
@@ -105,7 +107,7 @@ async function clerkOAuth(strategy) {
         class="mb-4 w-full"
         text="Criar conta"
         icon-right="arrow-right"
-        @click="createAccount()"
+        type="submit"
         :loading="loading"
       />
     </MForm>

--- a/apps/app/stores/clerk/signUp.ts
+++ b/apps/app/stores/clerk/signUp.ts
@@ -9,8 +9,8 @@ export const useSignUpStore = defineStore("signUp", {
       emailAddress,
       password,
     }: {
-      emailAddress: string;
-      password: string;
+      emailAddress: string | null;
+      password: string | null;
     }) {
       this.signUp = await this.$clerk.client.signUp.create({
         emailAddress,


### PR DESCRIPTION
## Resumo
Ao submeter a ação do formulário, clicando no botão para criar uma conta, é possível enviar uma requisição sem qualquer tipo de validação. Ou seja o formulário está submetendo sem as validações dos campos.


## Mudanças Realizadas
Em apps/app/pages/sign-up.vue. Anteriormente o método createAccount() estava partindo através do botão utilizando o @click. Agora o método createAccount()  está patindo do formulário através do @submit, sendo assim, fazendo validações antes de submeter o formulário. Foi posto em cada input o atributo de "required". 

## Tipo de Mudança
- [x] refactor: uma modificação de código já existente que corrige um bug ou aprimora a funcionalidade.

## Capturas de tela
![Peek 31-01-2024 22-37](https://github.com/menthorlabs/menthor/assets/40308971/5503adfc-c01d-43d6-b754-515608bc0fca)
