### PR TITLE
fix: change router.push to navigateTo after signOut()

### DIFF
--- a/apps/app/pages/sign-in.vue
+++ b/apps/app/pages/sign-in.vue
@@ -6,7 +6,6 @@ useSeoMeta({
   title: "Entre agora",
 });
 
-const router = useRouter();
 const signInStore = useSignInStore();
 const email = ref(null);
 const password = ref(null);
@@ -32,7 +31,9 @@ async function signIn() {
       password: password.value,
     });
     await sessionStore.refreshSession();
-    router.push("/");
+    return await navigateTo("/", {
+      external: true,
+    });
   } catch (e) {
     toast?.error("Email ou senha incorretos.");
   } finally {

--- a/apps/app/pages/sign-in.vue
+++ b/apps/app/pages/sign-in.vue
@@ -6,6 +6,7 @@ useSeoMeta({
   title: "Entre agora",
 });
 
+const router = useRouter();
 const signInStore = useSignInStore();
 const email = ref(null);
 const password = ref(null);
@@ -31,9 +32,7 @@ async function signIn() {
       password: password.value,
     });
     await sessionStore.refreshSession();
-    return await navigateTo("/", {
-      external: true,
-    });
+    router.push("/");
   } catch (e) {
     toast?.error("Email ou senha incorretos.");
   } finally {

--- a/apps/app/pages/sign-out.vue
+++ b/apps/app/pages/sign-out.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
-const router = useRouter();
+//const router = useRouter();
 const sessionStore = useSessionStore();
 onMounted(async () => {
   await sessionStore.signOut();
-  router.push("/sign-in");
+  navigateTo("/sign-in", {
+    external: true,
+  });
 });
 </script>
 

--- a/apps/app/pages/sign-out.vue
+++ b/apps/app/pages/sign-out.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-//const router = useRouter();
 const sessionStore = useSessionStore();
 onMounted(async () => {
   await sessionStore.signOut();


### PR DESCRIPTION
## Resumo
Após realizar signIn() com sucesso, o método "empurra" o usuário autenticado para rota raíz (/) utilizando router.push() e isso causa um problema de reatividade na página renderizada.

## Mudanças Realizadas
Seguindo a própria recomendação da documentação do Nuxt, https://nuxt.com/docs/api/composables/use-router, em apps/app/pages/sign-in, no método signIn(), foi substituído o router.push() pelo navigateTo() com a opção external defina como true. O navigateTo() diferente do router.push() não empurra a URL para pilha, mas faz o redirencionamento, digamos que completo, da URL, dessa forma a renderização é realizada com exatidão e assim corrigindo a problema de reatividade. 

## Tipo de Mudança
- [x] fix: uma correção de bug

## Capturas de tela
![methorio_fix_after_signin (1)](https://github.com/menthorlabs/menthor/assets/40308971/79644d75-75c1-470f-abf6-2554612d321b)
